### PR TITLE
[feature] #68 interestUpdate api

### DIFF
--- a/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/controller/interest/InterestController.java
+++ b/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/controller/interest/InterestController.java
@@ -1,7 +1,10 @@
 package com.skhu.mid_skhu.app.controller.interest;
 
 import com.skhu.mid_skhu.app.dto.interest.requestDto.InterestRegisterRequestDto;
+import com.skhu.mid_skhu.app.dto.interest.requestDto.InterestUpdateRequestDto;
 import com.skhu.mid_skhu.app.dto.interest.responseDto.InterestRegisterResponseDto;
+import com.skhu.mid_skhu.app.dto.interest.responseDto.InterestUpdateResponseDto;
+import com.skhu.mid_skhu.app.service.interest.InterestUpdateService;
 import com.skhu.mid_skhu.global.common.dto.ApiResponseTemplate;
 import com.skhu.mid_skhu.app.service.interest.InterestRegisterService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -24,6 +24,7 @@ import java.security.Principal;
 public class InterestController {
 
     private final InterestRegisterService registerService;
+    private final InterestUpdateService updateService;
 
     @PostMapping("/register")
     @Operation(
@@ -37,6 +38,22 @@ public class InterestController {
     public ResponseEntity<ApiResponseTemplate<InterestRegisterResponseDto>> interestRegister(@RequestBody InterestRegisterRequestDto requestDto,
                                                                                              Principal principal) {
         ApiResponseTemplate<InterestRegisterResponseDto> data = registerService.interestRegister(requestDto, principal);
+
+        return ResponseEntity.status(data.getStatus()).body(data);
+    }
+
+    @PutMapping("/update")
+    @Operation(
+            summary = "관심사 수정",
+            description = "관심사를 List로 받고 받은 관심사 정보를 해당 사용자 정보에 업데이트합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "관심사 수정 성공"),
+                    @ApiResponse(responseCode = "403", description = "url문제 or 관리자 문의"),
+                    @ApiResponse(responseCode = "500", description = "토큰 문제 or 관리자 문의")
+            })
+    public ResponseEntity<ApiResponseTemplate<InterestUpdateResponseDto>> interestUpdate(@RequestBody InterestUpdateRequestDto requestDto,
+                                                                                         Principal principal) {
+        ApiResponseTemplate<InterestUpdateResponseDto> data = updateService.interestUpdate(requestDto, principal);
 
         return ResponseEntity.status(data.getStatus()).body(data);
     }

--- a/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/dto/interest/requestDto/InterestUpdateRequestDto.java
+++ b/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/dto/interest/requestDto/InterestUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.skhu.mid_skhu.app.dto.interest.requestDto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class InterestUpdateRequestDto {
+
+    private List<String> interestCategoryList;
+}

--- a/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/dto/interest/responseDto/InterestUpdateResponseDto.java
+++ b/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/dto/interest/responseDto/InterestUpdateResponseDto.java
@@ -1,0 +1,13 @@
+package com.skhu.mid_skhu.app.dto.interest.responseDto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class InterestUpdateResponseDto {
+
+    private List<String> interestCategoryList;
+}

--- a/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/service/interest/InterestUpdateService.java
+++ b/MID_SKHU/src/main/java/com/skhu/mid_skhu/app/service/interest/InterestUpdateService.java
@@ -1,0 +1,64 @@
+package com.skhu.mid_skhu.app.service.interest;
+
+import com.skhu.mid_skhu.app.dto.interest.requestDto.InterestUpdateRequestDto;
+import com.skhu.mid_skhu.app.dto.interest.responseDto.InterestUpdateResponseDto;
+import com.skhu.mid_skhu.app.entity.interest.InterestCategory;
+import com.skhu.mid_skhu.app.entity.student.Student;
+import com.skhu.mid_skhu.global.common.dto.ApiResponseTemplate;
+import com.skhu.mid_skhu.global.exception.ErrorCode;
+import com.skhu.mid_skhu.global.exception.model.CustomException;
+import com.skhu.mid_skhu.app.repository.StudentRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestUpdateService {
+
+    private final StudentRepository studentRepository;
+
+    @Transactional
+    public ApiResponseTemplate<InterestUpdateResponseDto> interestUpdate(InterestUpdateRequestDto requestDto, Principal principal) {
+
+        Long studentId = Long.parseLong(principal.getName());
+
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ID_EXCEPTION,
+                        "학생 : " + ErrorCode.NOT_FOUND_ID_EXCEPTION.getMessage()));
+
+        List<InterestCategory> newCategories = requestDto.getInterestCategoryList().stream()
+                .map(InterestCategory::convertToCategory)
+                .collect(Collectors.toList());
+
+        List<InterestCategory> existingCategories = student.getCategory();
+
+        for (InterestCategory newCategory : newCategories) {
+            if (!existingCategories.contains(newCategory)) {
+                existingCategories.add(newCategory);
+            }
+        }
+
+        existingCategories.retainAll(newCategories);
+
+        studentRepository.save(student);
+
+        InterestUpdateResponseDto responseDto = InterestUpdateResponseDto.builder()
+                .interestCategoryList(existingCategories.stream()
+                        .map(InterestCategory::getDisplayName)
+                        .collect(Collectors.toList()))
+                .build();
+
+        return ApiResponseTemplate.<InterestUpdateResponseDto>builder()
+                .status(200)
+                .success(true)
+                .message("관심사 수정 성공")
+                .data(responseDto)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🌿 제목
- 사용자의 관심사 수정을 위한 interestUpdate api 구현

## 🌱 작업한 내용
- 사용자의 관심사를 수정하는 api를 개발했습니다
- 새로운 관심사 중 기존 관심사에 없는 것을 추가하고, 기존 관심사 중 새로운 관심사에 없는 것을 제거하는 방법으로 구현했습니다
- Postman을 사용하여 테스트 완료했습니다

<img width="936" alt="스크린샷 2024-06-11 오후 10 38 59" src="https://github.com/Team-MID-in-SKHU/MID-Backend/assets/143769463/4d296883-b0a2-47eb-a90e-db0ccd14e78c">

<img width="936" alt="스크린샷 2024-06-11 오후 10 39 13" src="https://github.com/Team-MID-in-SKHU/MID-Backend/assets/143769463/6037fd89-cb20-453b-b5ad-6ed87c5e92e8">


🍀 관련 이슈
Resolved: #68